### PR TITLE
QWERTY Workspace Order

### DIFF
--- a/SwipeAeroSpace/SettingsView.swift
+++ b/SwipeAeroSpace/SettingsView.swift
@@ -5,6 +5,7 @@ struct SettingsView: View {
     @AppStorage("wrap") private var wrapWorkspace: Bool = false
     @AppStorage("natrual") private var naturalSwipe: Bool = true
     @AppStorage("skip-empty") private var skipEmpty: Bool = false
+    @AppStorage("qwerty-swipe") private var qwertySwipe: Bool = false
     
     @State private var numberFormatter: NumberFormatter = {
         var nf = NumberFormatter()
@@ -44,6 +45,11 @@ struct SettingsView: View {
             VStack(alignment: .leading){
                 Toggle("Natural Swipe", isOn: $naturalSwipe)
                 Text("Disable to use reversed swipe ").foregroundStyle(.secondary)
+            }.padding(.vertical, 4)
+            
+            VStack(alignment: .leading){
+                Toggle("QWERTY Swipe", isOn: $qwertySwipe)
+                Text("Swipe direction is based on QWERTY keyboard").foregroundStyle(.secondary)
             }.padding(.vertical, 4)
             
             VStack(alignment: .leading){

--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -183,7 +183,7 @@ class SwipeManager {
             }()
 
         if normalizedCurrentIndex == -1 {
-            return .failure(.SocketError)
+            return .failure(.CommandFail("Workspace not found"))
         }
 
         let count = workspaceOrder.count
@@ -208,7 +208,7 @@ class SwipeManager {
             }
         }
 
-        return .failure(.SocketError)
+        return .failure(.CommandFail("Workspace not found"))
     }
 
     func nextWorkspace() {


### PR DESCRIPTION
Swipe through workspaces in a custom order: numbers (1–9) first, then follow the physical QWERTY keyboard layout.
Great for setups where workspaces are mapped to keyboard positions.