### PR TITLE
feat: multi-workspace swipe with live feedback

### DIFF
--- a/SwipeAeroSpace/SettingsView.swift
+++ b/SwipeAeroSpace/SettingsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @AppStorage("threshold") private static var swipeThreshold: Double = 0.3
+    @AppStorage("threshold") private static var swipeThreshold: Double = 1.0
     @AppStorage("wrap") private var wrapWorkspace: Bool = false
     @AppStorage("natrual") private var naturalSwipe: Bool = true
     @AppStorage("skip-empty") private var skipEmpty: Bool = false
@@ -17,73 +17,101 @@ struct SettingsView: View {
         return nf
     }()
 
-    let numbers = ["Three", "Four"]
+    let fingerOptions = ["Three", "Four"]
 
     var swipeManager: SwipeManager
     @ObservedObject var socketInfo: SocketInfo
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading) {
-                HStack {
-                    Text("Socket Status: ")
-                    Image(systemName: "circle.fill").foregroundStyle(
-                        socketInfo.socketConnected ? .green : .red
-                    )
+        VStack(alignment: .leading, spacing: 0) {
+
+            // MARK: - Connection
+            sectionHeader("Connection")
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    Image(systemName: "circle.fill")
+                        .font(.system(size: 8))
+                        .foregroundStyle(socketInfo.socketConnected ? .green : .red)
+                    Text(socketInfo.socketConnected ? "Connected to AeroSpace" : "Not connected")
                 }
                 if !socketInfo.socketConnected {
-                    Button("Try to connect socket") {
+                    Button("Reconnect") {
                         swipeManager.connectSocket(reconnect: true)
                     }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
                 }
             }
-            Form {
-                TextField(
-                    "Swipe Threshold",
-                    value: SettingsView.$swipeThreshold,
-                    formatter: numberFormatter,
-                    prompt: Text("0.3")
-                ).textFieldStyle(RoundedBorderTextFieldStyle()).frame(
-                    maxWidth: 200
-                )
-            }
+            .padding(.horizontal, 32)
+            .padding(.bottom, 16)
 
-            Picker("Number of Fingers:", selection: $fingers) {
-                ForEach(numbers, id: \.self) {
-                    Text($0)
+            sectionDivider()
+
+            // MARK: - Horizontal Swipe
+            sectionHeader("Horizontal Swipe")
+            VStack(alignment: .leading, spacing: 12) {
+                settingRow(
+                    title: "Sensitivity",
+                    description: "Lower values require less finger movement to switch. Default: 1.0"
+                ) {
+                    TextField(
+                        "Sensitivity",
+                        value: SettingsView.$swipeThreshold,
+                        formatter: numberFormatter,
+                        prompt: Text("1.0")
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 80)
                 }
-            }
-            .pickerStyle(.segmented)
-            .frame(maxWidth: 400)
-            .padding(.vertical, 4)
 
-            VStack(alignment: .leading) {
-                Toggle("Wrap Workspace", isOn: $wrapWorkspace)
-                Text("Enable to jump between first and last workspaces")
-                    .foregroundStyle(.secondary)
-            }.padding(.vertical, 4)
+                settingRow(
+                    title: "Number of Fingers",
+                    description: "How many fingers trigger a horizontal workspace switch"
+                ) {
+                    Picker("", selection: $fingers) {
+                        ForEach(fingerOptions, id: \.self) { Text($0) }
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(maxWidth: 140)
+                }
 
-            VStack(alignment: .leading) {
-                Toggle("Natural Swipe", isOn: $naturalSwipe)
-                Text("Disable to use reversed swipe ").foregroundStyle(
-                    .secondary
-                )
-            }.padding(.vertical, 4)
+                settingRow(
+                    title: "Natural Swipe",
+                    description: "Swipe direction matches finger movement, like trackpad scrolling"
+                ) {
+                    Toggle("", isOn: $naturalSwipe)
+                        .labelsHidden()
+                }
 
-            VStack(alignment: .leading) {
-                Toggle("Skip Empty Workspace", isOn: $skipEmpty)
-                Text("Enable to skip empty workspaces").foregroundStyle(
-                    .secondary
-                )
-            }.padding(.vertical, 4)
+                settingRow(
+                    title: "Wrap Around",
+                    description: "Swiping past the last workspace jumps back to the first"
+                ) {
+                    Toggle("", isOn: $wrapWorkspace)
+                        .labelsHidden()
+                }
 
-            VStack(alignment: .leading) {
-                Toggle("Multi-Workspace Swipe", isOn: $multiSwipeEnabled)
-                Text("Longer swipes jump multiple workspaces at once")
-                    .foregroundStyle(.secondary)
+                settingRow(
+                    title: "Skip Empty",
+                    description: "Only land on workspaces that have windows"
+                ) {
+                    Toggle("", isOn: $skipEmpty)
+                        .labelsHidden()
+                }
+
+                settingRow(
+                    title: "Multi-Workspace Swipe",
+                    description: "Longer swipes jump multiple workspaces in one gesture"
+                ) {
+                    Toggle("", isOn: $multiSwipeEnabled)
+                        .labelsHidden()
+                }
+
                 if multiSwipeEnabled {
-                    HStack {
-                        Text("Max workspaces per swipe: \(maxSteps)")
+                    settingRow(
+                        title: "Max per Swipe: \(maxSteps)",
+                        description: "Maximum number of workspaces a single swipe can jump"
+                    ) {
                         Slider(
                             value: Binding(
                                 get: { Double(maxSteps) },
@@ -91,34 +119,93 @@ struct SettingsView: View {
                             ),
                             in: 2...9,
                             step: 1
-                        ).frame(maxWidth: 200)
-                    }.padding(.top, 4)
-                }
-            }.padding(.vertical, 4)
-
-            VStack(alignment: .leading) {
-                Toggle("Workspace Overview on Swipe Up", isOn: $swipeUpOverviewEnabled)
-                Text("Swipe up to see all workspaces and their apps")
-                    .foregroundStyle(.secondary)
-                if swipeUpOverviewEnabled {
-                    Picker("Swipe Up Fingers:", selection: $swipeUpFingers) {
-                        ForEach(numbers, id: \.self) {
-                            Text($0)
-                        }
+                        )
+                        .frame(maxWidth: 140)
                     }
-                    .pickerStyle(.segmented)
-                    .frame(maxWidth: 200)
-                    .padding(.top, 4)
                 }
-            }.padding(.vertical, 4)
-
-            LaunchAtLogin.Toggle {
-                Text("Launch At Login")
             }
-        }
-        .padding(.horizontal, 32)
-        .padding(.vertical, 24)
+            .padding(.horizontal, 32)
+            .padding(.bottom, 16)
 
+            sectionDivider()
+
+            // MARK: - Workspace Overview
+            sectionHeader("Workspace Overview")
+            VStack(alignment: .leading, spacing: 12) {
+                settingRow(
+                    title: "Enable Overview",
+                    description: "Swipe up to see all workspaces and their apps"
+                ) {
+                    Toggle("", isOn: $swipeUpOverviewEnabled)
+                        .labelsHidden()
+                }
+
+                if swipeUpOverviewEnabled {
+                    settingRow(
+                        title: "Number of Fingers",
+                        description: "How many fingers trigger the workspace overview"
+                    ) {
+                        Picker("", selection: $swipeUpFingers) {
+                            ForEach(fingerOptions, id: \.self) { Text($0) }
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(maxWidth: 140)
+                    }
+                }
+            }
+            .padding(.horizontal, 32)
+            .padding(.bottom, 16)
+
+            sectionDivider()
+
+            // MARK: - General
+            sectionHeader("General")
+            VStack(alignment: .leading, spacing: 12) {
+                LaunchAtLogin.Toggle {
+                    Text("Launch at Login")
+                }
+            }
+            .padding(.horizontal, 32)
+            .padding(.bottom, 24)
+        }
+        .padding(.vertical, 8)
+        .frame(width: 600)
+    }
+
+    // MARK: - Components
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .textCase(.uppercase)
+            .padding(.horizontal, 32)
+            .padding(.top, 16)
+            .padding(.bottom, 8)
+    }
+
+    private func sectionDivider() -> some View {
+        Divider()
+            .padding(.horizontal, 24)
+    }
+
+    private func settingRow<Content: View>(
+        title: String,
+        description: String,
+        @ViewBuilder control: () -> Content
+    ) -> some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13))
+                Text(description)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+            control()
+        }
     }
 }
 

--- a/SwipeAeroSpace/SettingsView.swift
+++ b/SwipeAeroSpace/SettingsView.swift
@@ -6,6 +6,8 @@ struct SettingsView: View {
     @AppStorage("natrual") private var naturalSwipe: Bool = true
     @AppStorage("skip-empty") private var skipEmpty: Bool = false
     @AppStorage("fingers") private var fingers: String = "Three"
+    @AppStorage("multiSwipe") private var multiSwipeEnabled: Bool = true
+    @AppStorage("maxSteps") private var maxSteps: Int = 5
 
     @State private var numberFormatter: NumberFormatter = {
         var nf = NumberFormatter()
@@ -71,6 +73,25 @@ struct SettingsView: View {
                 Text("Enable to skip empty workspaces").foregroundStyle(
                     .secondary
                 )
+            }.padding(.vertical, 4)
+
+            VStack(alignment: .leading) {
+                Toggle("Multi-Workspace Swipe", isOn: $multiSwipeEnabled)
+                Text("Longer swipes jump multiple workspaces at once")
+                    .foregroundStyle(.secondary)
+                if multiSwipeEnabled {
+                    HStack {
+                        Text("Max workspaces per swipe: \(maxSteps)")
+                        Slider(
+                            value: Binding(
+                                get: { Double(maxSteps) },
+                                set: { maxSteps = Int($0) }
+                            ),
+                            in: 2...9,
+                            step: 1
+                        ).frame(maxWidth: 200)
+                    }.padding(.top, 4)
+                }
             }.padding(.vertical, 4)
 
             LaunchAtLogin.Toggle {

--- a/SwipeAeroSpace/SettingsView.swift
+++ b/SwipeAeroSpace/SettingsView.swift
@@ -8,6 +8,8 @@ struct SettingsView: View {
     @AppStorage("fingers") private var fingers: String = "Three"
     @AppStorage("multiSwipe") private var multiSwipeEnabled: Bool = true
     @AppStorage("maxSteps") private var maxSteps: Int = 5
+    @AppStorage("swipeUpOverview") private var swipeUpOverviewEnabled: Bool = true
+    @AppStorage("swipeUpFingers") private var swipeUpFingers: String = "Three"
 
     @State private var numberFormatter: NumberFormatter = {
         var nf = NumberFormatter()
@@ -91,6 +93,22 @@ struct SettingsView: View {
                             step: 1
                         ).frame(maxWidth: 200)
                     }.padding(.top, 4)
+                }
+            }.padding(.vertical, 4)
+
+            VStack(alignment: .leading) {
+                Toggle("Workspace Overview on Swipe Up", isOn: $swipeUpOverviewEnabled)
+                Text("Swipe up to see all workspaces and their apps")
+                    .foregroundStyle(.secondary)
+                if swipeUpOverviewEnabled {
+                    Picker("Swipe Up Fingers:", selection: $swipeUpFingers) {
+                        ForEach(numbers, id: \.self) {
+                            Text($0)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(maxWidth: 200)
+                    .padding(.top, 4)
                 }
             }.padding(.vertical, 4)
 

--- a/SwipeAeroSpace/SwipeAeroSpaceApp.swift
+++ b/SwipeAeroSpace/SwipeAeroSpaceApp.swift
@@ -50,6 +50,10 @@ struct SwipeAeroSpaceApp: App {
             image: "MenubarIcon",
             isInserted: $menuBarExtraIsInserted
         ) {
+            Button("Workspace Overview") {
+                swipeManager.showWorkspaceOverview()
+            }
+            Divider()
             Button("Next Workspace") {
                 swipeManager.nextWorkspace()
             }

--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -92,7 +92,7 @@ extension Result {
 
 class SwipeManager {
     // user settings
-    @AppStorage("threshold") private var swipeThreshold: Double = 0.3
+    @AppStorage("threshold") private var swipeThreshold: Double = 0.15
     @AppStorage("wrap") private var wrapWorkspace: Bool = false
     @AppStorage("natrual") private var naturalSwipe: Bool = true
     @AppStorage("skip-empty") private var skipEmpty: Bool = false
@@ -489,16 +489,7 @@ class SwipeManager {
             // Only fire horizontal workspace switches for horizontal swipes
             if swipeAxis == .horizontal && multiSwipeEnabled {
                 let threshold = Float(swipeThreshold)
-                // Each additional step requires 1.5x more distance to avoid
-                // accidental multi-switches on long single swipes
-                let dist = abs(accDisX)
-                var steps = 0
-                var nextBoundary = threshold
-                while dist >= nextBoundary && steps < maxSteps {
-                    steps += 1
-                    nextBoundary += threshold * (1.0 + 0.5 * Float(steps))
-                }
-                let rawPosition = accDisX >= 0 ? steps : -steps
+                let rawPosition = Int(accDisX / threshold)
                 let targetPosition = max(-maxSteps, min(maxSteps, rawPosition))
                 let delta = targetPosition - firedPosition
 

--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -25,6 +25,12 @@ enum GestureState {
     case cancelled
 }
 
+enum SwipeAxis {
+    case undecided
+    case horizontal
+    case vertical
+}
+
 enum SwipeError: Error {
     case SocketError(String)
     case CommandFail(String)
@@ -93,16 +99,22 @@ class SwipeManager {
     @AppStorage("fingers") private var fingers: String = "Three"
     @AppStorage("multiSwipe") private var multiSwipeEnabled: Bool = true
     @AppStorage("maxSteps") private var maxSteps: Int = 5
+    @AppStorage("swipeUpOverview") private var swipeUpOverviewEnabled: Bool = true
+    @AppStorage("swipeUpFingers") private var swipeUpFingers: String = "Three"
 
     var socketInfo = SocketInfo()
 
     private var eventTap: CFMachPort? = nil
     private var accDisX: Float = 0
+    private var accDisY: Float = 0
+    private var swipeUpFired: Bool = false
     private var firedPosition: Int = 0
     private var prevTouchPositions: [String: NSPoint] = [:]
     private var state: GestureState = .ended
+    private var swipeAxis: SwipeAxis = .undecided
     private var socket: Socket? = nil
     private let workQueue = DispatchQueue(label: "swipe.workspace", qos: .userInteractive)
+    private let overlayController = OverlayPanelController()
 
     private var logger: Logger = Logger(
         subsystem: Bundle.main.bundleIdentifier!,
@@ -156,6 +168,70 @@ class SwipeManager {
             "list-workspaces", "--monitor", "focused", "--empty", "no",
         ]
         return runCommand(args: args, stdin: "")
+    }
+
+    func showWorkspaceOverview() {
+        workQueue.async { [weak self] in
+            guard let self = self else { return }
+            let workspaces = self.queryWorkspaces()
+            DispatchQueue.main.async {
+                self.overlayController.show(workspaces: workspaces) { [weak self] wsName in
+                    self?.workQueue.async {
+                        _ = self?.runCommand(args: ["workspace", wsName], stdin: "")
+                    }
+                }
+            }
+        }
+    }
+
+    private func queryWorkspaces() -> [WorkspaceInfo] {
+        // Get focused workspace
+        let focusedResult = runCommand(
+            args: ["list-workspaces", "--focused"], stdin: ""
+        )
+        let focusedWs = (try? focusedResult.get())?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ) ?? ""
+
+        // Get all non-empty workspaces on all monitors
+        let allResult = runCommand(
+            args: ["list-workspaces", "--monitor", "all", "--empty", "no"],
+            stdin: ""
+        )
+        guard let allOutput = try? allResult.get() else { return [] }
+        let wsNames = allOutput.split(separator: "\n").map(String.init)
+
+        return wsNames.compactMap { wsName in
+            let winResult = runCommand(
+                args: [
+                    "list-windows", "--workspace", wsName,
+                    "--format", "%{app-name}|%{window-title}",
+                ],
+                stdin: ""
+            )
+            let windows: [WindowInfo]
+            if let winOutput = try? winResult.get(),
+                !winOutput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                windows = winOutput.split(separator: "\n").enumerated().map {
+                    idx, line in
+                    let parts = line.split(separator: "|", maxSplits: 1)
+                    return WindowInfo(
+                        id: "\(wsName)-\(idx)",
+                        appName: parts.first.map(String.init) ?? "Unknown",
+                        windowTitle: parts.count > 1
+                            ? String(parts[1]) : ""
+                    )
+                }
+            } else {
+                windows = []
+            }
+            return WorkspaceInfo(
+                id: wsName,
+                windows: windows,
+                isFocused: wsName == focusedWs
+            )
+        }
     }
 
     @discardableResult
@@ -310,23 +386,45 @@ class SwipeManager {
     private func stopGesture() {
         if state == .began {
             state = .ended
-            handleGesture()
+            if swipeAxis != .vertical {
+                handleGesture()
+            }
             clearEventState()
         }
     }
 
     private func processTouches(touches: Set<NSTouch>, count: Int) {
-        let finger_count = fingers == "Three" ? 3 : 4
-        if state != .began && count == finger_count {
+        let hFingerCount = fingers == "Three" ? 3 : 4
+        let vFingerCount = swipeUpFingers == "Three" ? 3 : 4
+        if state != .began && (count == hFingerCount || count == vFingerCount) {
             state = .began
         }
         if state == .began {
-            accDisX += horizontalSwipeDistance(touches: touches)
+            let (disX, disY) = swipeDistance(touches: touches)
+            accDisX += disX
+            accDisY += disY
 
-            // Fire workspace switches live as each threshold is crossed
-            if multiSwipeEnabled {
+            // Lock axis once we have enough movement
+            if swipeAxis == .undecided {
+                let threshold = Float(swipeThreshold) * 0.3
+                if abs(accDisX) > threshold || abs(accDisY) > threshold {
+                    swipeAxis =
+                        abs(accDisY) > abs(accDisX) ? .vertical : .horizontal
+                }
+            }
+
+            // Fire swipe-up overview as soon as threshold is crossed
+            if swipeAxis == .vertical && !swipeUpFired && swipeUpOverviewEnabled {
+                let threshold = Float(swipeThreshold) * 0.5
+                if accDisY > threshold {
+                    swipeUpFired = true
+                    showWorkspaceOverview()
+                }
+            }
+
+            // Only fire horizontal workspace switches for horizontal swipes
+            if swipeAxis == .horizontal && multiSwipeEnabled {
                 let threshold = Float(swipeThreshold)
-                // Signed position: negative = swiped left, positive = swiped right
                 let rawPosition = Int(accDisX / threshold)
                 let targetPosition = max(-maxSteps, min(maxSteps, rawPosition))
                 let delta = targetPosition - firedPosition
@@ -358,7 +456,10 @@ class SwipeManager {
 
     private func clearEventState() {
         accDisX = 0
+        accDisY = 0
         firedPosition = 0
+        swipeUpFired = false
+        swipeAxis = .undecided
         prevTouchPositions.removeAll()
     }
 
@@ -387,15 +488,19 @@ class SwipeManager {
         }
     }
 
-    private func horizontalSwipeDistance(touches: Set<NSTouch>) -> Float {
+    private func swipeDistance(touches: Set<NSTouch>) -> (Float, Float) {
         var allRight = true
         var allLeft = true
+        var allUp = true
+        var allDown = true
         var sumDisX = Float(0)
         var sumDisY = Float(0)
         for touch in touches {
             let (disX, disY) = touchDistance(touch)
             allRight = allRight && disX >= 0
             allLeft = allLeft && disX <= 0
+            allUp = allUp && disY >= 0
+            allDown = allDown && disY <= 0
             sumDisX += disX
             sumDisY += disY
 
@@ -406,17 +511,19 @@ class SwipeManager {
                     touch.normalizedPosition
             }
         }
-        // All fingers should move in the same direction.
+
+        var resultX = sumDisX
+        var resultY = sumDisY
+
+        // All fingers should move in the same direction for each axis.
         if !allRight && !allLeft {
-            return 0
+            resultX = 0
+        }
+        if !allUp && !allDown {
+            resultY = 0
         }
 
-        // Only horizontal swipes are interesting.
-        if abs(sumDisX) <= abs(sumDisY) {
-            return 0
-        }
-
-        return sumDisX
+        return (resultX, resultY)
     }
 
     private func touchDistance(_ touch: NSTouch) -> (Float, Float) {

--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -174,12 +174,27 @@ class SwipeManager {
         workQueue.async { [weak self] in
             guard let self = self else { return }
             let workspaces = self.queryWorkspaces()
+            let originalWs = workspaces.first(where: { $0.isFocused })?.id
             DispatchQueue.main.async {
-                self.overlayController.show(workspaces: workspaces) { [weak self] wsName in
-                    self?.workQueue.async {
-                        _ = self?.runCommand(args: ["workspace", wsName], stdin: "")
+                self.overlayController.show(
+                    workspaces: workspaces,
+                    onSelect: { [weak self] wsName in
+                        self?.workQueue.async {
+                            _ = self?.runCommand(args: ["workspace", wsName], stdin: "")
+                        }
+                    },
+                    onPreview: { [weak self] wsName in
+                        self?.workQueue.async {
+                            _ = self?.runCommand(args: ["workspace", wsName], stdin: "")
+                        }
+                    },
+                    onRevert: { [weak self] in
+                        guard let originalWs = originalWs else { return }
+                        self?.workQueue.async {
+                            _ = self?.runCommand(args: ["workspace", originalWs], stdin: "")
+                        }
                     }
-                }
+                )
             }
         }
     }

--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -91,14 +91,18 @@ class SwipeManager {
     @AppStorage("natrual") private var naturalSwipe: Bool = true
     @AppStorage("skip-empty") private var skipEmpty: Bool = false
     @AppStorage("fingers") private var fingers: String = "Three"
+    @AppStorage("multiSwipe") private var multiSwipeEnabled: Bool = true
+    @AppStorage("maxSteps") private var maxSteps: Int = 5
 
     var socketInfo = SocketInfo()
 
     private var eventTap: CFMachPort? = nil
     private var accDisX: Float = 0
+    private var firedPosition: Int = 0
     private var prevTouchPositions: [String: NSPoint] = [:]
     private var state: GestureState = .ended
     private var socket: Socket? = nil
+    private let workQueue = DispatchQueue(label: "swipe.workspace", qos: .userInteractive)
 
     private var logger: Logger = Logger(
         subsystem: Bundle.main.bundleIdentifier!,
@@ -318,17 +322,53 @@ class SwipeManager {
         }
         if state == .began {
             accDisX += horizontalSwipeDistance(touches: touches)
+
+            // Fire workspace switches live as each threshold is crossed
+            if multiSwipeEnabled {
+                let threshold = Float(swipeThreshold)
+                // Signed position: negative = swiped left, positive = swiped right
+                let rawPosition = Int(accDisX / threshold)
+                let targetPosition = max(-maxSteps, min(maxSteps, rawPosition))
+                let delta = targetPosition - firedPosition
+
+                if delta != 0 {
+                    let direction: Direction
+                    if delta > 0 {
+                        direction = naturalSwipe ? .prev : .next
+                    } else {
+                        direction = naturalSwipe ? .next : .prev
+                    }
+                    let stepsToFire = abs(delta)
+                    firedPosition = targetPosition
+                    workQueue.async { [weak self] in
+                        guard let self = self else { return }
+                        for _ in 0..<stepsToFire {
+                            switch self.switchWorkspace(direction: direction) {
+                            case .success: continue
+                            case .failure(let err):
+                                self.logger.error("\(err.localizedDescription)")
+                                return
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
     private func clearEventState() {
         accDisX = 0
+        firedPosition = 0
         prevTouchPositions.removeAll()
     }
 
     private func handleGesture() {
-        // filter
-        if abs(accDisX) < Float(swipeThreshold) {
+        // If multi-swipe is enabled, switches already fired live during the gesture
+        if multiSwipeEnabled {
+            return
+        }
+        let threshold = Float(swipeThreshold)
+        if abs(accDisX) < threshold {
             return
         }
         let direction: Direction =
@@ -337,9 +377,13 @@ class SwipeManager {
             } else {
                 accDisX < 0 ? .prev : .next
             }
-        switch switchWorkspace(direction: direction) {
-        case .success: return
-        case .failure(let err): logger.error("\(err.localizedDescription)")
+        workQueue.async { [weak self] in
+            guard let self = self else { return }
+            switch self.switchWorkspace(direction: direction) {
+            case .success: return
+            case .failure(let err):
+                self.logger.error("\(err.localizedDescription)")
+            }
         }
     }
 

--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -112,6 +112,7 @@ class SwipeManager {
     private var prevTouchPositions: [String: NSPoint] = [:]
     private var state: GestureState = .ended
     private var swipeAxis: SwipeAxis = .undecided
+    private var activeFingerCount: Int = 0
     private var socket: Socket? = nil
     private let workQueue = DispatchQueue(label: "swipe.workspace", qos: .userInteractive)
     private let overlayController = OverlayPanelController()
@@ -208,18 +209,43 @@ class SwipeManager {
             in: .whitespacesAndNewlines
         ) ?? ""
 
-        // Get all non-empty workspaces on all monitors
+        // Get monitor names
+        let monitorResult = runCommand(
+            args: [
+                "list-monitors", "--format", "%{monitor-id}|%{monitor-name}",
+            ],
+            stdin: ""
+        )
+        var monitorNames: [String: String] = [:]
+        if let monitorOutput = try? monitorResult.get() {
+            for line in monitorOutput.split(separator: "\n") {
+                let parts = line.split(separator: "|", maxSplits: 1)
+                if parts.count == 2 {
+                    monitorNames[String(parts[0])] = String(parts[1])
+                }
+            }
+        }
+
+        // Get all non-empty workspaces on all monitors (with monitor IDs)
         let allResult = runCommand(
-            args: ["list-workspaces", "--monitor", "all", "--empty", "no"],
+            args: [
+                "list-workspaces", "--monitor", "all", "--empty", "no",
+                "--format", "%{workspace}|%{monitor-id}",
+            ],
             stdin: ""
         )
         guard let allOutput = try? allResult.get() else { return [] }
-        let wsNames = allOutput.split(separator: "\n").map(String.init)
+        let wsEntries: [(name: String, monitorId: String)] =
+            allOutput.split(separator: "\n").compactMap { line in
+                let parts = line.split(separator: "|", maxSplits: 1)
+                guard parts.count == 2 else { return nil }
+                return (name: String(parts[0]), monitorId: String(parts[1]))
+            }
 
-        return wsNames.compactMap { wsName in
+        return wsEntries.compactMap { entry in
             let winResult = runCommand(
                 args: [
-                    "list-windows", "--workspace", wsName,
+                    "list-windows", "--workspace", entry.name,
                     "--format", "%{app-name}|%{window-title}",
                 ],
                 stdin: ""
@@ -232,7 +258,7 @@ class SwipeManager {
                     idx, line in
                     let parts = line.split(separator: "|", maxSplits: 1)
                     return WindowInfo(
-                        id: "\(wsName)-\(idx)",
+                        id: "\(entry.name)-\(idx)",
                         appName: parts.first.map(String.init) ?? "Unknown",
                         windowTitle: parts.count > 1
                             ? String(parts[1]) : ""
@@ -242,9 +268,11 @@ class SwipeManager {
                 windows = []
             }
             return WorkspaceInfo(
-                id: wsName,
+                id: entry.name,
                 windows: windows,
-                isFocused: wsName == focusedWs
+                isFocused: entry.name == focusedWs,
+                monitorId: entry.monitorId,
+                monitorName: monitorNames[entry.monitorId] ?? "Monitor \(entry.monitorId)"
             )
         }
     }
@@ -413,6 +441,7 @@ class SwipeManager {
         let vFingerCount = swipeUpFingers == "Three" ? 3 : 4
         if state != .began && (count == hFingerCount || count == vFingerCount) {
             state = .began
+            activeFingerCount = count
         }
         if state == .began {
             let (disX, disY) = swipeDistance(touches: touches)
@@ -428,19 +457,48 @@ class SwipeManager {
                 }
             }
 
-            // Fire swipe-up overview as soon as threshold is crossed
-            if swipeAxis == .vertical && !swipeUpFired && swipeUpOverviewEnabled {
+            // Vertical swipes: only fire if finger count matches overview setting
+            if swipeAxis == .vertical && swipeUpOverviewEnabled
+                && activeFingerCount == vFingerCount
+            {
                 let threshold = Float(swipeThreshold) * 0.5
-                if accDisY > threshold {
+                if !swipeUpFired && accDisY > threshold {
                     swipeUpFired = true
-                    showWorkspaceOverview()
+                    if !overlayController.isVisible {
+                        showWorkspaceOverview()
+                    }
+                }
+                // Mid-gesture: swipe back down dismisses when accDisY reverses
+                if swipeUpFired && accDisY < threshold * 0.5 {
+                    swipeUpFired = false
+                    DispatchQueue.main.async { [weak self] in
+                        self?.overlayController.dismiss()
+                    }
+                }
+                // New gesture: swipe down dismisses if overlay is already open
+                if !swipeUpFired && accDisY < -threshold
+                    && overlayController.isVisible
+                {
+                    swipeUpFired = true
+                    DispatchQueue.main.async { [weak self] in
+                        self?.overlayController.dismiss()
+                    }
                 }
             }
 
             // Only fire horizontal workspace switches for horizontal swipes
             if swipeAxis == .horizontal && multiSwipeEnabled {
                 let threshold = Float(swipeThreshold)
-                let rawPosition = Int(accDisX / threshold)
+                // Each additional step requires 1.5x more distance to avoid
+                // accidental multi-switches on long single swipes
+                let dist = abs(accDisX)
+                var steps = 0
+                var nextBoundary = threshold
+                while dist >= nextBoundary && steps < maxSteps {
+                    steps += 1
+                    nextBoundary += threshold * (1.0 + 0.5 * Float(steps))
+                }
+                let rawPosition = accDisX >= 0 ? steps : -steps
                 let targetPosition = max(-maxSteps, min(maxSteps, rawPosition))
                 let delta = targetPosition - firedPosition
 
@@ -475,6 +533,7 @@ class SwipeManager {
         firedPosition = 0
         swipeUpFired = false
         swipeAxis = .undecided
+        activeFingerCount = 0
         prevTouchPositions.removeAll()
     }
 

--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -92,7 +92,8 @@ extension Result {
 
 class SwipeManager {
     // user settings
-    @AppStorage("threshold") private var swipeThreshold: Double = 0.15
+    @AppStorage("threshold") private var swipeThreshold: Double = 1.0
+    private var internalThreshold: Float { Float(swipeThreshold) * 0.05 }
     @AppStorage("wrap") private var wrapWorkspace: Bool = false
     @AppStorage("natrual") private var naturalSwipe: Bool = true
     @AppStorage("skip-empty") private var skipEmpty: Bool = false
@@ -113,6 +114,8 @@ class SwipeManager {
     private var state: GestureState = .ended
     private var swipeAxis: SwipeAxis = .undecided
     private var activeFingerCount: Int = 0
+    private var gestureFocusDone: Bool = false
+    private var pendingSwipeWork: DispatchWorkItem? = nil
     private var socket: Socket? = nil
     private let workQueue = DispatchQueue(label: "swipe.workspace", qos: .userInteractive)
     private let overlayController = OverlayPanelController()
@@ -174,34 +177,58 @@ class SwipeManager {
     func showWorkspaceOverview() {
         workQueue.async { [weak self] in
             guard let self = self else { return }
-            let workspaces = self.queryWorkspaces()
-            let originalWs = workspaces.first(where: { $0.isFocused })?.id
-            DispatchQueue.main.async {
-                self.overlayController.show(
-                    workspaces: workspaces,
-                    onSelect: { [weak self] wsName in
+            // Phase 1: quick query (3 socket calls) — show immediately
+            let (shellWorkspaces, originalWs, focusedMonitorId) = self.queryWorkspacesShell()
+            let originalWsOpt: String? = originalWs.isEmpty ? nil : originalWs
+
+            let makeCallbacks: () -> (
+                onSelect: (String) -> Void,
+                onPreview: (String) -> Void,
+                onRevert: () -> Void
+            ) = { [weak self] in
+                (
+                    onSelect: { wsName in
                         self?.workQueue.async {
                             _ = self?.runCommand(args: ["workspace", wsName], stdin: "")
                         }
                     },
-                    onPreview: { [weak self] wsName in
+                    onPreview: { wsName in
                         self?.workQueue.async {
                             _ = self?.runCommand(args: ["workspace", wsName], stdin: "")
                         }
                     },
-                    onRevert: { [weak self] in
-                        guard let originalWs = originalWs else { return }
+                    onRevert: {
+                        guard let originalWs = originalWsOpt else { return }
                         self?.workQueue.async {
                             _ = self?.runCommand(args: ["workspace", originalWs], stdin: "")
                         }
                     }
                 )
             }
+
+            let cb = makeCallbacks()
+            DispatchQueue.main.async {
+                self.overlayController.show(
+                    workspaces: shellWorkspaces,
+                    focusedMonitorId: focusedMonitorId,
+                    onSelect: cb.onSelect,
+                    onPreview: cb.onPreview,
+                    onRevert: cb.onRevert
+                )
+            }
+
+            // Phase 2: fetch window details and update in place
+            let fullWorkspaces = self.queryWindows(for: shellWorkspaces)
+            DispatchQueue.main.async {
+                guard self.overlayController.isVisible else { return }
+                self.overlayController.update(workspaces: fullWorkspaces)
+            }
         }
     }
 
-    private func queryWorkspaces() -> [WorkspaceInfo] {
-        // Get focused workspace
+    /// Quick query: workspace names, monitors, focused state (4 socket calls)
+    /// Returns (workspaces, focusedWorkspaceName, focusedMonitorId)
+    private func queryWorkspacesShell() -> ([WorkspaceInfo], String, String?) {
         let focusedResult = runCommand(
             args: ["list-workspaces", "--focused"], stdin: ""
         )
@@ -209,7 +236,15 @@ class SwipeManager {
             in: .whitespacesAndNewlines
         ) ?? ""
 
-        // Get monitor names
+        // Get the monitor ID for the focused workspace
+        let focusedMonitorResult = runCommand(
+            args: ["list-workspaces", "--focused", "--format", "%{monitor-id}"],
+            stdin: ""
+        )
+        let focusedMonitorId = (try? focusedMonitorResult.get())?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+
         let monitorResult = runCommand(
             args: [
                 "list-monitors", "--format", "%{monitor-id}|%{monitor-name}",
@@ -226,7 +261,6 @@ class SwipeManager {
             }
         }
 
-        // Get all non-empty workspaces on all monitors (with monitor IDs)
         let allResult = runCommand(
             args: [
                 "list-workspaces", "--monitor", "all", "--empty", "no",
@@ -234,18 +268,30 @@ class SwipeManager {
             ],
             stdin: ""
         )
-        guard let allOutput = try? allResult.get() else { return [] }
-        let wsEntries: [(name: String, monitorId: String)] =
-            allOutput.split(separator: "\n").compactMap { line in
-                let parts = line.split(separator: "|", maxSplits: 1)
-                guard parts.count == 2 else { return nil }
-                return (name: String(parts[0]), monitorId: String(parts[1]))
-            }
+        guard let allOutput = try? allResult.get() else { return ([], focusedWs, focusedMonitorId) }
 
-        return wsEntries.compactMap { entry in
+        let workspaces: [WorkspaceInfo] = allOutput.split(separator: "\n").compactMap { line in
+            let parts = line.split(separator: "|", maxSplits: 1)
+            guard parts.count == 2 else { return nil }
+            let name = String(parts[0])
+            let monitorId = String(parts[1])
+            return WorkspaceInfo(
+                id: name,
+                windows: [],
+                isFocused: name == focusedWs,
+                monitorId: monitorId,
+                monitorName: monitorNames[monitorId] ?? "Monitor \(monitorId)"
+            )
+        }
+        return (workspaces, focusedWs, focusedMonitorId)
+    }
+
+    /// Fetch window details for a list of workspaces (1 socket call per workspace)
+    private func queryWindows(for workspaces: [WorkspaceInfo]) -> [WorkspaceInfo] {
+        return workspaces.map { ws in
             let winResult = runCommand(
                 args: [
-                    "list-windows", "--workspace", entry.name,
+                    "list-windows", "--workspace", ws.id,
                     "--format", "%{app-name}|%{window-title}",
                 ],
                 stdin: ""
@@ -258,7 +304,7 @@ class SwipeManager {
                     idx, line in
                     let parts = line.split(separator: "|", maxSplits: 1)
                     return WindowInfo(
-                        id: "\(entry.name)-\(idx)",
+                        id: "\(ws.id)-\(idx)",
                         appName: parts.first.map(String.init) ?? "Unknown",
                         windowTitle: parts.count > 1
                             ? String(parts[1]) : ""
@@ -268,11 +314,11 @@ class SwipeManager {
                 windows = []
             }
             return WorkspaceInfo(
-                id: entry.name,
+                id: ws.id,
                 windows: windows,
-                isFocused: entry.name == focusedWs,
-                monitorId: entry.monitorId,
-                monitorName: monitorNames[entry.monitorId] ?? "Monitor \(entry.monitorId)"
+                isFocused: ws.isFocused,
+                monitorId: ws.monitorId,
+                monitorName: ws.monitorName
             )
         }
     }
@@ -443,6 +489,11 @@ class SwipeManager {
             state = .began
             activeFingerCount = count
         }
+        // Update finger count while axis is still undecided — touch count
+        // can fluctuate as fingers land, so use the latest stable count
+        if state == .began && swipeAxis == .undecided {
+            activeFingerCount = count
+        }
         if state == .began {
             let (disX, disY) = swipeDistance(touches: touches)
             accDisX += disX
@@ -450,7 +501,7 @@ class SwipeManager {
 
             // Lock axis once we have enough movement
             if swipeAxis == .undecided {
-                let threshold = Float(swipeThreshold) * 0.3
+                let threshold = internalThreshold * 0.3
                 if abs(accDisX) > threshold || abs(accDisY) > threshold {
                     swipeAxis =
                         abs(accDisY) > abs(accDisX) ? .vertical : .horizontal
@@ -461,7 +512,7 @@ class SwipeManager {
             if swipeAxis == .vertical && swipeUpOverviewEnabled
                 && activeFingerCount == vFingerCount
             {
-                let threshold = Float(swipeThreshold) * 0.5
+                let threshold = internalThreshold * 0.5
                 if !swipeUpFired && accDisY > threshold {
                     swipeUpFired = true
                     if !overlayController.isVisible {
@@ -488,7 +539,7 @@ class SwipeManager {
 
             // Only fire horizontal workspace switches for horizontal swipes
             if swipeAxis == .horizontal && multiSwipeEnabled {
-                let threshold = Float(swipeThreshold)
+                let threshold = internalThreshold
                 let rawPosition = Int(accDisX / threshold)
                 let targetPosition = max(-maxSteps, min(maxSteps, rawPosition))
                 let delta = targetPosition - firedPosition
@@ -502,10 +553,39 @@ class SwipeManager {
                     }
                     let stepsToFire = abs(delta)
                     firedPosition = targetPosition
-                    workQueue.async { [weak self] in
+
+                    // Cancel any pending work so we don't overshoot
+                    pendingSwipeWork?.cancel()
+
+                    let workItem = DispatchWorkItem { [weak self] in
                         guard let self = self else { return }
+
+                        // Focus the workspace under the cursor once per gesture
+                        if !self.gestureFocusDone {
+                            let res = self.runCommand(
+                                args: ["list-workspaces", "--monitor", "mouse", "--visible"],
+                                stdin: ""
+                            )
+                            if let mouseWs = try? res.get() {
+                                _ = self.runCommand(args: ["workspace", mouseWs], stdin: "")
+                            }
+                            self.gestureFocusDone = true
+                        }
+
+                        // Fire only the lean next/prev calls
                         for _ in 0..<stepsToFire {
-                            switch self.switchWorkspace(direction: direction) {
+                            var args = ["workspace", direction.value]
+                            var stdin = ""
+                            if self.wrapWorkspace {
+                                args.append("--wrap-around")
+                            }
+                            if self.skipEmpty {
+                                if let ws = try? self.getNonEmptyWorkspaces().get(), !ws.isEmpty {
+                                    stdin = ws
+                                    args.append("--stdin")
+                                }
+                            }
+                            switch self.runCommand(args: args, stdin: stdin) {
                             case .success: continue
                             case .failure(let err):
                                 self.logger.error("\(err.localizedDescription)")
@@ -513,6 +593,8 @@ class SwipeManager {
                             }
                         }
                     }
+                    pendingSwipeWork = workItem
+                    workQueue.async(execute: workItem)
                 }
             }
         }
@@ -525,6 +607,7 @@ class SwipeManager {
         swipeUpFired = false
         swipeAxis = .undecided
         activeFingerCount = 0
+        gestureFocusDone = false
         prevTouchPositions.removeAll()
     }
 
@@ -533,7 +616,7 @@ class SwipeManager {
         if multiSwipeEnabled {
             return
         }
-        let threshold = Float(swipeThreshold)
+        let threshold = internalThreshold
         if abs(accDisX) < threshold {
             return
         }
@@ -560,6 +643,7 @@ class SwipeManager {
         var allDown = true
         var sumDisX = Float(0)
         var sumDisY = Float(0)
+        var activeTouches = 0
         for touch in touches {
             let (disX, disY) = touchDistance(touch)
             allRight = allRight && disX >= 0
@@ -574,11 +658,15 @@ class SwipeManager {
             } else {
                 prevTouchPositions["\(touch.identity)"] =
                     touch.normalizedPosition
+                activeTouches += 1
             }
         }
 
-        var resultX = sumDisX
-        var resultY = sumDisY
+        // Average across fingers so threshold behaves consistently
+        // regardless of finger count
+        let count = max(activeTouches, 1)
+        var resultX = sumDisX / Float(count)
+        var resultY = sumDisY / Float(count)
 
         // All fingers should move in the same direction for each axis.
         if !allRight && !allLeft {

--- a/SwipeAeroSpace/WorkspaceOverlayView.swift
+++ b/SwipeAeroSpace/WorkspaceOverlayView.swift
@@ -1,0 +1,238 @@
+import Cocoa
+import SwiftUI
+
+struct WorkspaceInfo: Identifiable {
+    let id: String  // workspace name
+    let windows: [WindowInfo]
+    let isFocused: Bool
+}
+
+struct WindowInfo: Identifiable {
+    let id: String
+    let appName: String
+    let windowTitle: String
+}
+
+struct WorkspaceOverlayView: View {
+    let workspaces: [WorkspaceInfo]
+    let onSelect: (String) -> Void
+    let onDismiss: () -> Void
+    @State private var appeared = false
+
+    private var columnCount: Int {
+        min(workspaces.count, 5)
+    }
+
+    private let maxColumns = 5
+
+    private var rows: [[WorkspaceInfo]] {
+        stride(from: 0, to: workspaces.count, by: maxColumns).map {
+            Array(workspaces[$0..<min($0 + maxColumns, workspaces.count)])
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Workspaces")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 8) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                    HStack(alignment: .top, spacing: 10) {
+                        ForEach(row) { ws in
+                            WorkspaceCard(workspace: ws)
+                                .onTapGesture { onSelect(ws.id) }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(radius: 20)
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 8)
+        .scaleEffect(appeared ? 1 : 0.98)
+        .onExitCommand { onDismiss() }
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.06)) {
+                appeared = true
+            }
+        }
+    }
+}
+
+struct WorkspaceCard: View {
+    let workspace: WorkspaceInfo
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text(workspace.id)
+                    .font(.system(size: 14, weight: .bold))
+                Spacer()
+                if workspace.isFocused {
+                    Circle()
+                        .fill(.blue)
+                        .frame(width: 7, height: 7)
+                }
+            }
+
+            Rectangle()
+                .fill(Color.white.opacity(isHovered ? 0.3 : 0.15))
+                .frame(height: 1)
+
+            if workspace.windows.isEmpty {
+                Text("(empty)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(workspace.windows) { win in
+                        HStack(spacing: 5) {
+                            let icon = NSWorkspace.shared.icon(
+                                forFile: appPath(for: win.appName))
+                            Image(nsImage: icon)
+                                .resizable()
+                                .frame(width: 15, height: 15)
+                            Text(win.appName)
+                                .font(.system(size: 12))
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(width: 150, alignment: .leading)
+        .padding(10)
+        .background(
+            workspace.isFocused
+                ? Color.accentColor.opacity(isHovered ? 0.35 : 0.15)
+                : Color.white.opacity(isHovered ? 0.15 : 0.05)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.white.opacity(isHovered ? 0.5 : 0), lineWidth: 2)
+        )
+        .scaleEffect(isHovered ? 1.03 : 1.0)
+        .shadow(color: .accentColor.opacity(isHovered ? 0.2 : 0), radius: 8)
+        .animation(.easeOut(duration: 0.08), value: isHovered)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .contentShape(Rectangle())
+    }
+
+    private func appPath(for appName: String) -> String {
+        "/Applications/\(appName).app"
+    }
+}
+
+class KeyablePanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
+class OverlayPanelController {
+    private var panel: NSPanel?
+    private var localMonitor: Any?
+    private var globalMonitor: Any?
+
+    func show(workspaces: [WorkspaceInfo], onSelect: @escaping (String) -> Void) {
+        dismiss()
+
+        let view = WorkspaceOverlayView(
+            workspaces: workspaces,
+            onSelect: { [weak self] ws in
+                onSelect(ws)
+                self?.dismiss()
+            },
+            onDismiss: { [weak self] in
+                self?.dismiss()
+            }
+        )
+
+        let hostingView = NSHostingView(rootView: view)
+
+        // Force layout and get intrinsic size
+        let intrinsicSize = hostingView.intrinsicContentSize
+        let width = max(intrinsicSize.width, 400)
+        let height = max(intrinsicSize.height, 200)
+        hostingView.setFrameSize(NSSize(width: width, height: height))
+
+        guard let screen = NSScreen.main else { return }
+        let screenFrame = screen.visibleFrame
+
+        let panelWidth = min(width, screenFrame.width * 0.9)
+        let panelHeight = min(height, screenFrame.height * 0.8)
+
+        let x = screenFrame.midX - panelWidth / 2
+        let y = screenFrame.midY - panelHeight / 2
+
+        let panel = KeyablePanel(
+            contentRect: NSRect(x: x, y: y, width: panelWidth, height: panelHeight),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.contentView = hostingView
+
+        // Activate the app briefly so the panel can receive key events
+        NSApp.activate(ignoringOtherApps: true)
+        panel.makeKeyAndOrderFront(nil)
+        self.panel = panel
+
+        // Local monitor catches Escape when the panel is key
+        localMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.keyDown, .leftMouseDown, .rightMouseDown]
+        ) { [weak self] event in
+            if event.type == .keyDown && event.keyCode == 53 {
+                self?.dismiss()
+                return nil
+            }
+            if event.type == .leftMouseDown || event.type == .rightMouseDown {
+                let screenPoint = NSEvent.mouseLocation
+                if let panel = self?.panel,
+                    !NSPointInRect(screenPoint, panel.frame)
+                {
+                    self?.dismiss()
+                }
+            }
+            return event
+        }
+
+        // Global monitor catches clicks/Escape when another app is focused
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .keyDown]
+        ) { [weak self] event in
+            if event.type == .keyDown && event.keyCode == 53 {
+                self?.dismiss()
+                return
+            }
+            if event.type == .leftMouseDown || event.type == .rightMouseDown {
+                self?.dismiss()
+            }
+        }
+    }
+
+    func dismiss() {
+        panel?.orderOut(nil)
+        panel = nil
+        if let localMonitor = localMonitor {
+            NSEvent.removeMonitor(localMonitor)
+            self.localMonitor = nil
+        }
+        if let globalMonitor = globalMonitor {
+            NSEvent.removeMonitor(globalMonitor)
+            self.globalMonitor = nil
+        }
+    }
+}

--- a/SwipeAeroSpace/WorkspaceOverlayView.swift
+++ b/SwipeAeroSpace/WorkspaceOverlayView.swift
@@ -17,23 +17,24 @@ struct WindowInfo: Identifiable {
 
 class OverlayState: ObservableObject {
     @Published var hoveredWorkspace: String? = nil
+    @Published var workspaces: [WorkspaceInfo] = []
+    @Published var visible: Bool = false
+    @Published var focusedMonitorId: String? = nil
 }
 
 struct WorkspaceOverlayView: View {
-    let workspaces: [WorkspaceInfo]
     let onSelect: (String) -> Void
     let onPreview: (String) -> Void
     let onDismiss: () -> Void
     @ObservedObject var overlayState: OverlayState
-    @State private var appeared = false
     @State private var revertTask: DispatchWorkItem? = nil
 
     private let maxColumns = 5
     private var focusedMonitorId: String? {
-        workspaces.first(where: { $0.isFocused })?.monitorId
+        overlayState.focusedMonitorId
     }
     private var hasMultipleMonitors: Bool {
-        Set(workspaces.map(\.monitorId)).count > 1
+        Set(overlayState.workspaces.map(\.monitorId)).count > 1
     }
 
     private struct MonitorGroup: Identifiable {
@@ -45,7 +46,7 @@ struct WorkspaceOverlayView: View {
     private var monitorGroups: [MonitorGroup] {
         var seen: [String: Int] = [:]
         var groups: [MonitorGroup] = []
-        for ws in workspaces {
+        for ws in overlayState.workspaces {
             if let idx = seen[ws.monitorId] {
                 groups[idx] = MonitorGroup(
                     id: groups[idx].id,
@@ -135,13 +136,14 @@ struct WorkspaceOverlayView: View {
         .background(.ultraThinMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .shadow(radius: 20)
-        .opacity(appeared ? 1 : 0)
-        .offset(y: appeared ? 0 : 8)
-        .scaleEffect(appeared ? 1 : 0.98)
+        .padding(24)
+        .opacity(overlayState.visible ? 1 : 0)
+        .offset(y: overlayState.visible ? 0 : 8)
+        .scaleEffect(overlayState.visible ? 1 : 0.98)
         .onExitCommand { onDismiss() }
         .onAppear {
-            withAnimation(.easeOut(duration: 0.06)) {
-                appeared = true
+            withAnimation(.easeOut(duration: 0.15)) {
+                overlayState.visible = true
             }
         }
     }
@@ -245,12 +247,15 @@ class OverlayPanelController {
 
     func show(
         workspaces: [WorkspaceInfo],
+        focusedMonitorId: String? = nil,
         onSelect: @escaping (String) -> Void,
         onPreview: @escaping (String) -> Void,
         onRevert: @escaping () -> Void
     ) {
         dismiss()
         isVisible = true
+        overlayState.visible = false
+        overlayState.focusedMonitorId = focusedMonitorId
 
         let selectHandler: (String) -> Void = { [weak self] ws in
             self?.onDismissCallback = nil  // Don't revert on select
@@ -258,9 +263,9 @@ class OverlayPanelController {
             self?.dismiss()
         }
         self.onSelectCallback = selectHandler
+        overlayState.workspaces = workspaces
 
         let view = WorkspaceOverlayView(
-            workspaces: workspaces,
             onSelect: selectHandler,
             onPreview: { ws in
                 onPreview(ws)
@@ -310,11 +315,8 @@ class OverlayPanelController {
         panel.level = .floating
         panel.isOpaque = false
         panel.backgroundColor = .clear
-        panel.hasShadow = true
+        panel.hasShadow = false
 
-        wrapper.wantsLayer = true
-        wrapper.layer?.cornerRadius = 16
-        wrapper.layer?.masksToBounds = true
         panel.contentView = wrapper
 
         NSApp.activate(ignoringOtherApps: true)
@@ -358,14 +360,29 @@ class OverlayPanelController {
         }
     }
 
+    func update(workspaces: [WorkspaceInfo]) {
+        overlayState.workspaces = workspaces
+    }
+
     func dismiss() {
+        guard isVisible else { return }
         isVisible = false
         onDismissCallback?()
         onDismissCallback = nil
         onSelectCallback = nil
         overlayState.hoveredWorkspace = nil
-        panel?.orderOut(nil)
-        panel = nil
+        overlayState.focusedMonitorId = nil
+
+        // Animate out, then tear down
+        withAnimation(.easeIn(duration: 0.1)) {
+            overlayState.visible = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [self] in
+            overlayState.workspaces = []
+            panel?.orderOut(nil)
+            panel = nil
+        }
+
         if let localMonitor = localMonitor {
             NSEvent.removeMonitor(localMonitor)
             self.localMonitor = nil

--- a/SwipeAeroSpace/WorkspaceOverlayView.swift
+++ b/SwipeAeroSpace/WorkspaceOverlayView.swift
@@ -163,7 +163,11 @@ class OverlayPanelController {
         let height = max(intrinsicSize.height, 200)
         hostingView.setFrameSize(NSSize(width: width, height: height))
 
-        guard let screen = NSScreen.main else { return }
+        // Show on the screen where the cursor is
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first(where: {
+            NSPointInRect(mouseLocation, $0.frame)
+        }) ?? NSScreen.main ?? NSScreen.screens.first!
         let screenFrame = screen.visibleFrame
 
         let panelWidth = min(width, screenFrame.width * 0.9)
@@ -183,6 +187,10 @@ class OverlayPanelController {
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true
+
+        hostingView.wantsLayer = true
+        hostingView.layer?.cornerRadius = 16
+        hostingView.layer?.masksToBounds = true
         panel.contentView = hostingView
 
         // Activate the app briefly so the panel can receive key events

--- a/SwipeAeroSpace/WorkspaceOverlayView.swift
+++ b/SwipeAeroSpace/WorkspaceOverlayView.swift
@@ -16,12 +16,11 @@ struct WindowInfo: Identifiable {
 struct WorkspaceOverlayView: View {
     let workspaces: [WorkspaceInfo]
     let onSelect: (String) -> Void
+    let onPreview: (String) -> Void
     let onDismiss: () -> Void
     @State private var appeared = false
-
-    private var columnCount: Int {
-        min(workspaces.count, 5)
-    }
+    @State private var hoveredWorkspace: String? = nil
+    @State private var revertTask: DispatchWorkItem? = nil
 
     private let maxColumns = 5
 
@@ -41,8 +40,27 @@ struct WorkspaceOverlayView: View {
                 ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
                     HStack(alignment: .top, spacing: 10) {
                         ForEach(row) { ws in
-                            WorkspaceCard(workspace: ws)
-                                .onTapGesture { onSelect(ws.id) }
+                            WorkspaceCard(
+                                workspace: ws,
+                                isHoveredExternally: hoveredWorkspace == ws.id
+                            )
+                            .onTapGesture { onSelect(ws.id) }
+                            .onHover { hovering in
+                                if hovering {
+                                    revertTask?.cancel()
+                                    revertTask = nil
+                                    hoveredWorkspace = ws.id
+                                    onPreview(ws.id)
+                                } else if hoveredWorkspace == ws.id {
+                                    hoveredWorkspace = nil
+                                    let task = DispatchWorkItem {
+                                        onDismiss()
+                                    }
+                                    revertTask = task
+                                    DispatchQueue.main.asyncAfter(
+                                        deadline: .now() + 0.08, execute: task)
+                                }
+                            }
                         }
                     }
                 }
@@ -66,7 +84,10 @@ struct WorkspaceOverlayView: View {
 
 struct WorkspaceCard: View {
     let workspace: WorkspaceInfo
+    var isHoveredExternally: Bool = false
     @State private var isHovered = false
+
+    private var highlighted: Bool { isHovered || isHoveredExternally }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
@@ -82,7 +103,7 @@ struct WorkspaceCard: View {
             }
 
             Rectangle()
-                .fill(Color.white.opacity(isHovered ? 0.3 : 0.15))
+                .fill(Color.white.opacity(highlighted ? 0.3 : 0.15))
                 .frame(height: 1)
 
             if workspace.windows.isEmpty {
@@ -110,17 +131,17 @@ struct WorkspaceCard: View {
         .padding(10)
         .background(
             workspace.isFocused
-                ? Color.accentColor.opacity(isHovered ? 0.35 : 0.15)
-                : Color.white.opacity(isHovered ? 0.15 : 0.05)
+                ? Color.accentColor.opacity(highlighted ? 0.35 : 0.15)
+                : Color.white.opacity(highlighted ? 0.25 : 0.05)
         )
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .overlay(
             RoundedRectangle(cornerRadius: 10)
-                .stroke(Color.white.opacity(isHovered ? 0.5 : 0), lineWidth: 2)
+                .stroke(Color.white.opacity(highlighted ? 0.5 : 0), lineWidth: 2)
         )
-        .scaleEffect(isHovered ? 1.03 : 1.0)
-        .shadow(color: .accentColor.opacity(isHovered ? 0.2 : 0), radius: 8)
-        .animation(.easeOut(duration: 0.08), value: isHovered)
+        .scaleEffect(highlighted ? 1.03 : 1.0)
+        .shadow(color: .accentColor.opacity(highlighted ? 0.2 : 0), radius: 8)
+        .animation(.easeOut(duration: 0.08), value: highlighted)
         .onHover { hovering in
             isHovered = hovering
         }
@@ -140,20 +161,32 @@ class OverlayPanelController {
     private var panel: NSPanel?
     private var localMonitor: Any?
     private var globalMonitor: Any?
+    private var onDismissCallback: (() -> Void)?
 
-    func show(workspaces: [WorkspaceInfo], onSelect: @escaping (String) -> Void) {
+    func show(
+        workspaces: [WorkspaceInfo],
+        onSelect: @escaping (String) -> Void,
+        onPreview: @escaping (String) -> Void,
+        onRevert: @escaping () -> Void
+    ) {
         dismiss()
 
         let view = WorkspaceOverlayView(
             workspaces: workspaces,
             onSelect: { [weak self] ws in
+                self?.onDismissCallback = nil  // Don't revert on select
                 onSelect(ws)
                 self?.dismiss()
             },
-            onDismiss: { [weak self] in
-                self?.dismiss()
+            onPreview: { ws in
+                onPreview(ws)
+            },
+            onDismiss: {
+                onRevert()
             }
         )
+
+        self.onDismissCallback = onRevert
 
         let hostingView = NSHostingView(rootView: view)
 
@@ -232,6 +265,8 @@ class OverlayPanelController {
     }
 
     func dismiss() {
+        onDismissCallback?()
+        onDismissCallback = nil
         panel?.orderOut(nil)
         panel = nil
         if let localMonitor = localMonitor {

--- a/SwipeAeroSpace/WorkspaceOverlayView.swift
+++ b/SwipeAeroSpace/WorkspaceOverlayView.swift
@@ -5,6 +5,8 @@ struct WorkspaceInfo: Identifiable {
     let id: String  // workspace name
     let windows: [WindowInfo]
     let isFocused: Bool
+    let monitorId: String
+    let monitorName: String
 }
 
 struct WindowInfo: Identifiable {
@@ -13,20 +15,56 @@ struct WindowInfo: Identifiable {
     let windowTitle: String
 }
 
+class OverlayState: ObservableObject {
+    @Published var hoveredWorkspace: String? = nil
+}
+
 struct WorkspaceOverlayView: View {
     let workspaces: [WorkspaceInfo]
     let onSelect: (String) -> Void
     let onPreview: (String) -> Void
     let onDismiss: () -> Void
+    @ObservedObject var overlayState: OverlayState
     @State private var appeared = false
-    @State private var hoveredWorkspace: String? = nil
     @State private var revertTask: DispatchWorkItem? = nil
 
     private let maxColumns = 5
+    private var focusedMonitorId: String? {
+        workspaces.first(where: { $0.isFocused })?.monitorId
+    }
+    private var hasMultipleMonitors: Bool {
+        Set(workspaces.map(\.monitorId)).count > 1
+    }
 
-    private var rows: [[WorkspaceInfo]] {
-        stride(from: 0, to: workspaces.count, by: maxColumns).map {
-            Array(workspaces[$0..<min($0 + maxColumns, workspaces.count)])
+    private struct MonitorGroup: Identifiable {
+        let id: String  // monitorId
+        let name: String
+        let workspaces: [WorkspaceInfo]
+    }
+
+    private var monitorGroups: [MonitorGroup] {
+        var seen: [String: Int] = [:]
+        var groups: [MonitorGroup] = []
+        for ws in workspaces {
+            if let idx = seen[ws.monitorId] {
+                groups[idx] = MonitorGroup(
+                    id: groups[idx].id,
+                    name: groups[idx].name,
+                    workspaces: groups[idx].workspaces + [ws]
+                )
+            } else {
+                seen[ws.monitorId] = groups.count
+                groups.append(MonitorGroup(
+                    id: ws.monitorId, name: ws.monitorName, workspaces: [ws]
+                ))
+            }
+        }
+        return groups
+    }
+
+    private func rows(for items: [WorkspaceInfo]) -> [[WorkspaceInfo]] {
+        stride(from: 0, to: items.count, by: maxColumns).map {
+            Array(items[$0..<min($0 + maxColumns, items.count)])
         }
     }
 
@@ -36,29 +74,56 @@ struct WorkspaceOverlayView: View {
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(.secondary)
 
-            VStack(spacing: 8) {
-                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
-                    HStack(alignment: .top, spacing: 10) {
-                        ForEach(row) { ws in
-                            WorkspaceCard(
-                                workspace: ws,
-                                isHoveredExternally: hoveredWorkspace == ws.id
-                            )
-                            .onTapGesture { onSelect(ws.id) }
-                            .onHover { hovering in
-                                if hovering {
-                                    revertTask?.cancel()
-                                    revertTask = nil
-                                    hoveredWorkspace = ws.id
-                                    onPreview(ws.id)
-                                } else if hoveredWorkspace == ws.id {
-                                    hoveredWorkspace = nil
-                                    let task = DispatchWorkItem {
-                                        onDismiss()
+            VStack(spacing: hasMultipleMonitors ? 16 : 8) {
+                ForEach(monitorGroups) { group in
+                    VStack(spacing: 8) {
+                        if hasMultipleMonitors {
+                            HStack {
+                                Rectangle()
+                                    .fill(.secondary.opacity(0.3))
+                                    .frame(height: 1)
+                                Text(group.name)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                Rectangle()
+                                    .fill(.secondary.opacity(0.3))
+                                    .frame(height: 1)
+                            }
+                        }
+                        ForEach(
+                            Array(rows(for: group.workspaces).enumerated()),
+                            id: \.offset
+                        ) { _, row in
+                            HStack(alignment: .top, spacing: 10) {
+                                ForEach(row) { ws in
+                                    Button { onSelect(ws.id) } label: {
+                                        WorkspaceCard(
+                                            workspace: ws,
+                                            isHoveredExternally: overlayState.hoveredWorkspace
+                                                == ws.id
+                                        )
                                     }
-                                    revertTask = task
-                                    DispatchQueue.main.asyncAfter(
-                                        deadline: .now() + 0.08, execute: task)
+                                    .buttonStyle(.plain)
+                                    .onHover { hovering in
+                                        if hovering {
+                                            revertTask?.cancel()
+                                            revertTask = nil
+                                            overlayState.hoveredWorkspace = ws.id
+                                            if ws.monitorId == focusedMonitorId {
+                                                onPreview(ws.id)
+                                            }
+                                        } else if overlayState.hoveredWorkspace == ws.id {
+                                            overlayState.hoveredWorkspace = nil
+                                            let task = DispatchWorkItem {
+                                                onDismiss()
+                                            }
+                                            revertTask = task
+                                            DispatchQueue.main.asyncAfter(
+                                                deadline: .now() + 0.08,
+                                                execute: task)
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -155,13 +220,28 @@ struct WorkspaceCard: View {
 
 class KeyablePanel: NSPanel {
     override var canBecomeKey: Bool { true }
+
+    override func sendEvent(_ event: NSEvent) {
+        // On mouse-down, make key first so SwiftUI receives the click immediately
+        if event.type == .leftMouseDown || event.type == .rightMouseDown {
+            makeKey()
+        }
+        super.sendEvent(event)
+    }
+}
+
+class FirstClickView: NSView {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 }
 
 class OverlayPanelController {
+    private(set) var isVisible: Bool = false
     private var panel: NSPanel?
     private var localMonitor: Any?
     private var globalMonitor: Any?
     private var onDismissCallback: (() -> Void)?
+    private var onSelectCallback: ((String) -> Void)?
+    private let overlayState = OverlayState()
 
     func show(
         workspaces: [WorkspaceInfo],
@@ -170,20 +250,25 @@ class OverlayPanelController {
         onRevert: @escaping () -> Void
     ) {
         dismiss()
+        isVisible = true
+
+        let selectHandler: (String) -> Void = { [weak self] ws in
+            self?.onDismissCallback = nil  // Don't revert on select
+            onSelect(ws)
+            self?.dismiss()
+        }
+        self.onSelectCallback = selectHandler
 
         let view = WorkspaceOverlayView(
             workspaces: workspaces,
-            onSelect: { [weak self] ws in
-                self?.onDismissCallback = nil  // Don't revert on select
-                onSelect(ws)
-                self?.dismiss()
-            },
+            onSelect: selectHandler,
             onPreview: { ws in
                 onPreview(ws)
             },
             onDismiss: {
                 onRevert()
-            }
+            },
+            overlayState: overlayState
         )
 
         self.onDismissCallback = onRevert
@@ -195,6 +280,12 @@ class OverlayPanelController {
         let width = max(intrinsicSize.width, 400)
         let height = max(intrinsicSize.height, 200)
         hostingView.setFrameSize(NSSize(width: width, height: height))
+
+        // Wrap in a view that accepts first mouse click without requiring activation
+        let wrapper = FirstClickView(frame: hostingView.frame)
+        hostingView.frame = wrapper.bounds
+        hostingView.autoresizingMask = [.width, .height]
+        wrapper.addSubview(hostingView)
 
         // Show on the screen where the cursor is
         let mouseLocation = NSEvent.mouseLocation
@@ -221,17 +312,16 @@ class OverlayPanelController {
         panel.backgroundColor = .clear
         panel.hasShadow = true
 
-        hostingView.wantsLayer = true
-        hostingView.layer?.cornerRadius = 16
-        hostingView.layer?.masksToBounds = true
-        panel.contentView = hostingView
+        wrapper.wantsLayer = true
+        wrapper.layer?.cornerRadius = 16
+        wrapper.layer?.masksToBounds = true
+        panel.contentView = wrapper
 
-        // Activate the app briefly so the panel can receive key events
         NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
         self.panel = panel
 
-        // Local monitor catches Escape when the panel is key
+        // Local monitor catches Escape and clicks when the panel is key
         localMonitor = NSEvent.addLocalMonitorForEvents(
             matching: [.keyDown, .leftMouseDown, .rightMouseDown]
         ) { [weak self] event in
@@ -245,6 +335,10 @@ class OverlayPanelController {
                     !NSPointInRect(screenPoint, panel.frame)
                 {
                     self?.dismiss()
+                } else if let ws = self?.overlayState.hoveredWorkspace {
+                    // Select the hovered workspace on first click
+                    self?.onSelectCallback?(ws)
+                    return nil
                 }
             }
             return event
@@ -265,8 +359,11 @@ class OverlayPanelController {
     }
 
     func dismiss() {
+        isVisible = false
         onDismissCallback?()
         onDismissCallback = nil
+        onSelectCallback = nil
+        overlayState.hoveredWorkspace = nil
         panel?.orderOut(nil)
         panel = nil
         if let localMonitor = localMonitor {


### PR DESCRIPTION
## Summary

- **Multi-workspace swipe**: longer swipes jump multiple workspaces in a single gesture, firing live as each threshold is crossed
- **Bidirectional mid-swipe**: reversing swipe direction without lifting fingers switches back immediately
- **Workspace overview (swipe up)**: 3/4-finger swipe up shows a floating overlay with all workspaces and their apps
- **Live workspace preview**: hovering a workspace card temporarily switches to that workspace; moving away reverts (80ms debounce)
- **Background socket I/O**: workspace switching dispatched to background queue
- **New settings**: multi-workspace swipe toggle, max workspaces slider, workspace overview toggle, swipe-up finger count picker

## Changes

- SwipeManager.swift: vertical swipe axis detection, queryWorkspaces, preview/revert callbacks
- WorkspaceOverlayView.swift (new): floating NSPanel overlay with workspace cards, hover preview, animations
- SettingsView.swift: new toggles and pickers
- SwipeAeroSpaceApp.swift: Workspace Overview menu bar button

## Notes

- Multi-workspace swipe defaults to enabled
- Workspace overview defaults to enabled with 3-finger swipe up
- Overlay appears on the monitor where the cursor is