### PR TITLE
fix: only count active touches to prevent 2-finger scroll triggering gestures

### DIFF
--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -294,8 +294,7 @@ class SwipeManager {
         if touches.isEmpty {
             return
         }
-        let touchesCount =
-            touches.allSatisfy({ $0.phase == .ended }) ? 0 : touches.count
+        let touchesCount = touches.filter({ $0.phase != .ended }).count
         if touchesCount == 0 {
             stopGesture()
         } else {


### PR DESCRIPTION
## Summary

Fixes #19 — 2-finger scroll was triggering workspace gestures because `.ended`-phase touches were included in the finger count, inflating 2-finger scrolls to appear as 3-finger gestures.

## Changes

- Filter out `.ended`-phase touches when counting active fingers in `touchEventHandler()`

## Root Cause

macOS delivers touch events with mixed phases — during a 2-finger scroll, the touch set can contain 2 active touches + 1 ended touch. The old logic counted all touches (3) when not all were ended, matching the 3-finger gesture threshold.

## Type

- [x] `fix` - Bug fix

## Testing

- Built and ran locally on macOS Sequoia
- 2-finger scroll no longer triggers workspace gestures
- 3-finger horizontal swipe still switches workspaces

## Breaking Changes

- [x] No breaking changes