### PR TITLE
fix: prevent 3-finger drag from triggering workspace switch (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 project.xcworkspace/
 xcuserdata/
 build*/
+
+# Agent planning artifacts
+.agent/

--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -490,9 +490,19 @@ class SwipeManager {
             activeFingerCount = count
         }
         // Update finger count while axis is still undecided — touch count
-        // can fluctuate as fingers land, so use the latest stable count
+        // can fluctuate as fingers land, so use the latest stable count.
+        // If the count leaves the valid range (e.g. a 3-finger drag briefly
+        // bumps to 4 via .stationary touches), cancel the spurious latch so
+        // it cannot carry forward into the axis-lock and fire a wrong gesture.
         if state == .began && swipeAxis == .undecided {
-            activeFingerCount = count
+            if count == hFingerCount || count == vFingerCount {
+                activeFingerCount = count
+            } else {
+                // Spurious latch — finger count is outside the valid range.
+                state = .ended
+                clearEventState()
+                return
+            }
         }
         if state == .began {
             let (disX, disY) = swipeDistance(touches: touches)
@@ -538,7 +548,9 @@ class SwipeManager {
             }
 
             // Only fire horizontal workspace switches for horizontal swipes
-            if swipeAxis == .horizontal && multiSwipeEnabled {
+            // and only when the active finger count matches the configured
+            // finger count (mirrors the guard on the vertical/overview path).
+            if swipeAxis == .horizontal && multiSwipeEnabled && activeFingerCount == hFingerCount {
                 let threshold = internalThreshold
                 let rawPosition = Int(accDisX / threshold)
                 let targetPosition = max(-maxSteps, min(maxSteps, rawPosition))

--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -463,8 +463,11 @@ class SwipeManager {
         if touches.isEmpty {
             return
         }
-        let touchesCount =
-            touches.allSatisfy({ $0.phase == .ended }) ? 0 : touches.count
+        // Count only active touches. macOS includes `.ended` (and sometimes
+        // `.stationary`) touches in the same event frame as moving fingers,
+        // which can briefly inflate the count and falsely latch the gesture
+        // (e.g. a 3-finger drag-to-select reporting count == 4 for one frame).
+        let touchesCount = touches.filter { $0.phase != .ended }.count
         if touchesCount == 0 {
             stopGesture()
         } else {
@@ -489,20 +492,17 @@ class SwipeManager {
             state = .began
             activeFingerCount = count
         }
-        // Update finger count while axis is still undecided — touch count
-        // can fluctuate as fingers land, so use the latest stable count.
-        // If the count leaves the valid range (e.g. a 3-finger drag briefly
-        // bumps to 4 via .stationary touches), cancel the spurious latch so
-        // it cannot carry forward into the axis-lock and fire a wrong gesture.
-        if state == .began && swipeAxis == .undecided {
-            if count == hFingerCount || count == vFingerCount {
-                activeFingerCount = count
-            } else {
-                // Spurious latch — finger count is outside the valid range.
-                state = .ended
-                clearEventState()
-                return
-            }
+        // While axis is still undecided, cancel the gesture if the active
+        // count drifts entirely outside the valid range (neither matches the
+        // horizontal nor the vertical finger count). Do NOT update
+        // `activeFingerCount` here — lowering it on a transient drop would
+        // silently swallow legitimate gestures where a finger briefly lifts.
+        if state == .began && swipeAxis == .undecided
+            && count != hFingerCount && count != vFingerCount
+        {
+            state = .ended
+            clearEventState()
+            return
         }
         if state == .began {
             let (disX, disY) = swipeDistance(touches: touches)
@@ -626,6 +626,12 @@ class SwipeManager {
     private func handleGesture() {
         // If multi-swipe is enabled, switches already fired live during the gesture
         if multiSwipeEnabled {
+            return
+        }
+        // Mirror the multi-swipe path's finger-count guard: only fire when
+        // the active count matches the configured horizontal finger count.
+        let hFingerCount = fingers == "Three" ? 3 : 4
+        if activeFingerCount != hFingerCount {
             return
         }
         let threshold = internalThreshold


### PR DESCRIPTION
## Summary

Fixes [#19](https://github.com/MediosZ/SwipeAeroSpace/issues/19) — a v0.3.0 regression where a 3-finger drag-to-select can trigger a workspace switch when the user has configured `fingers = Four`.

> I'm using SwipeAeroSpace with four finger swipes to change workspace, but the workspace change gets also triggered with 3 finger swipes. The issue is that I'm using 3 fingers dragging to select text, so most of the times I want to select text, I end up by changing workspace. This worked fine before version 0.3.0.

This PR supersedes #21 with a more comprehensive, layered fix.

## Root cause

`processTouches` latches `state = .began` the first time `count` reaches the configured finger count. macOS includes `.ended` (and sometimes `.stationary`) touches in the same event frame as still-active fingers, briefly inflating the count from 3 → 4 during a 3-finger drag. Combined with v0.3.0's new live-firing path and lower threshold (0.05 instead of 0.30), this latches at the wrong count and fires a workspace switch.

## Three layered defenses

### 1. Filter `.ended` touches in `touchEventHandler` (root cause)

```swift
let touchesCount = touches.filter { $0.phase != .ended }.count
```

This is the same fix proposed in #21 — eliminates phantom counts at the boundary so they never reach the state machine. Also resolves the related case where 2-finger scrolls were inflated to 3 by trailing `.ended` touches.

### 2. Add `activeFingerCount == hFingerCount` guard on the horizontal multi-swipe firing branch

Mirrors the guard that already existed on the vertical/overview path. Even if a phantom briefly latches at the wrong count, the live-fire path no longer triggers a workspace switch unless the active count matches the user's configured horizontal finger count.

### 3. Add the same finger-count guard to `handleGesture` (non-multiSwipe path)

Users who **disable multi-swipe** were still vulnerable because `handleGesture` (run on finger-lift) fires on `accDisX` alone. This closes that gap.

### 4. Cancel the gesture in-flight when count drifts outside the valid range while axis is undecided

Defense in depth. Notably, this does **not** lower `activeFingerCount` mid-gesture — that would silently swallow legitimate 4-finger swipes when a finger briefly lifts (count drops to 3, matches `vFingerCount`, locks in at 3, then the horizontal guard blocks the user's intent).

## Why this approach over #21 alone

#21 fixes the most common phantom case (`.ended` touches), which is sufficient for the default config. But:

- It doesn't help users who set `fingers = Four`, `swipeUpFingers = Four` if a `.stationary` palm or other phantom inflates the count
- It doesn't add a downstream guard, so any future change to the touch-counting logic could re-introduce the bug

The combined approach gives both a clean root-cause fix and downstream guards, without the regression Fix B (cancel-and-relatch) had in earlier iterations.

## Test plan

- [x] Build Debug (Xcode) — succeeds
- [ ] `fingers = Four`: 3-finger drag-to-select in TextEdit/Safari → workspace does NOT switch
- [ ] `fingers = Four`: 4-finger horizontal swipe → workspace switches
- [ ] `fingers = Four`: 4-finger swipe with brief finger-lift mid-swipe → still fires (regression check)
- [ ] `fingers = Four, multiSwipe = OFF`: 3-finger drag → no switch
- [ ] `fingers = Three`: 3-finger horizontal swipe → workspace switches
- [ ] `swipeUpFingers = Three`: 3-finger swipe up → overview opens
- [ ] 2-finger scroll → no overview trigger