### PR TITLE
fix: rename @AppStorage key from natrual to natural (breaking change)

### DIFF
--- a/SwipeAeroSpace/SettingsView.swift
+++ b/SwipeAeroSpace/SettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @AppStorage("threshold") private static var swipeThreshold: Double = 1.0
     @AppStorage("wrap") private var wrapWorkspace: Bool = false
-    @AppStorage("natrual") private var naturalSwipe: Bool = true
+    @AppStorage("natural") private var naturalSwipe: Bool = true
     @AppStorage("skip-empty") private var skipEmpty: Bool = false
     @AppStorage("fingers") private var fingers: String = "Three"
     @AppStorage("multiSwipe") private var multiSwipeEnabled: Bool = true

--- a/SwipeAeroSpace/SwipeManager.swift
+++ b/SwipeAeroSpace/SwipeManager.swift
@@ -90,7 +90,7 @@ class SwipeManager {
     @AppStorage("threshold") private var swipeThreshold: Double = 1.0
     private var internalThreshold: Float { Float(swipeThreshold) * 0.05 }
     @AppStorage("wrap") private var wrapWorkspace: Bool = false
-    @AppStorage("natrual") private var naturalSwipe: Bool = true
+    @AppStorage("natural") private var naturalSwipe: Bool = true
     @AppStorage("skip-empty") private var skipEmpty: Bool = false
     @AppStorage("fingers") private var fingers: String = "Three"
     @AppStorage("multiSwipe") private var multiSwipeEnabled: Bool = true


### PR DESCRIPTION
## Summary
Fix UserDefaults key typo in SwipeManager.swift: @AppStorage key `natrual` → `natural`.

## Changes
- Rename @AppStorage key in SwipeManager.swift: `natrual` → `natural`
- SettingsView.swift already uses `natural` (updated in previous commit)

## Breaking Change Note
⚠️ This is a **breaking change** for users with dotfiles or scripts referencing the `natrual` UserDefaults key. These users should update to use `natural` instead.

Per maintainer confirmation on issue #33: breaking change is acceptable for this typo fix.

Fixes #31